### PR TITLE
Implement coworking bookings lookup route

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,24 @@ export default tseslint.config({
   },
 })
 ```
+
+## API routes
+
+### `GET /coworkings/:id/bookings`
+
+Returns all bookings for workspaces that belong to the specified coworking.
+
+Example response:
+
+```json
+[
+  {
+    "id": 1,
+    "user_id": 2,
+    "worckspace_id": 5,
+    "start_time": "2024-08-01T10:00:00.000Z",
+    "end_time": "2024-08-01T12:00:00.000Z",
+    "status": "confirmed"
+  }
+]
+```

--- a/coworkease-backend/index.js
+++ b/coworkease-backend/index.js
@@ -95,6 +95,20 @@ app.get('/bookings', async (req, res) => {
     }
 });
 
+// Получить все бронирования коворкинга по его id
+app.get('/coworkings/:id/bookings', async (req, res) => {
+    try {
+        const { id } = req.params;
+        const result = await pool.query(
+            'SELECT b.* FROM "Bookings" b JOIN "Workspaces" w ON b.worckspace_id = w.id WHERE w.coworking_id = $1',
+            [id]
+        );
+        res.json(result.rows);
+    } catch (err) {
+        res.status(500).json({ error: err.message });
+    }
+});
+
 // Получить бронирование по id
 app.get('/bookings/:id', async (req, res) => {
     try {

--- a/src/BookingForm.tsx
+++ b/src/BookingForm.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+
+export type Booking = {
+  id: number;
+  user_id: number;
+  worckspace_id: number;
+  start_time: string;
+  end_time: string;
+  status: string;
+};
+
+export default function BookingForm({ coworkingId }: { coworkingId: number }) {
+  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`http://localhost:3000/coworkings/${coworkingId}/bookings`)
+      .then((res) => res.json())
+      .then((data) => {
+        setBookings(data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [coworkingId]);
+
+  if (loading) return <div>Загрузка бронирований...</div>;
+
+  return (
+    <div>
+      <h3>Занятые даты</h3>
+      <ul>
+        {bookings.map((b) => (
+          <li key={b.id}>
+            {new Date(b.start_time).toLocaleString()} – {" "}
+            {new Date(b.end_time).toLocaleString()}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/CoworkingDetails.tsx
+++ b/src/CoworkingDetails.tsx
@@ -1,5 +1,6 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
+import BookingForm from "./BookingForm";
 
 type Coworking = {
     id: number;
@@ -85,6 +86,7 @@ export default function CoworkingDetails() {
                     </ul>
                 </div>
             )}
+            <BookingForm coworkingId={Number(id)} />
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add route `GET /coworkings/:id/bookings`
- show coworking bookings in new `BookingForm` component
- render `BookingForm` on coworking details page
- document the new API endpoint

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841e25575fc832c9d1990b178f123df