### PR TITLE
Remove unused Material-UI deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@emotion/react": "^11.11.3",
-    "@emotion/styled": "^11.11.0",
-    "@mui/icons-material": "^5.15.10",
-    "@mui/material": "^5.15.10",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.1"


### PR DESCRIPTION
## Summary
- cleanup: remove Material-UI and Emotion packages from dependencies

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841e3cecee0832cbdbdff8e9cccfd13